### PR TITLE
Added support for setting the full connection string in the config file

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ var CheckEvent = require('./models/checkEvent');
 var Ping       = require('./models/ping');
 
 // configure mongodb
-mongoose.connect('mongodb://' + config.mongodb.user + ':' + config.mongodb.password + '@' + config.mongodb.server +'/' + config.mongodb.database);
+mongoose.connect(config.mongodb.connectionString || 'mongodb://' + config.mongodb.user + ':' + config.mongodb.password + '@' + config.mongodb.server +'/' + config.mongodb.database);
 mongoose.connection.on('error', function (err) {
   console.error('MongoDB error: ' + err.message);
   console.error('Make sure a mongoDB server is running and accessible by this application')


### PR DESCRIPTION
Adds support for setting the full mongo connection string in the config file. If the connection string is passed, the other mongo parameters are ignored.

I had to include this because I am deploying Uptime into a Heroku app and they only provide me a environment variable with the full connection string.
