### PR TITLE
Looks like "engines" is preferred over "engine"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "keywords": ["uptime", "monitoring", "api", "check"],
   "repository": "https://github.com/fzaninotto/uptime",
   "license": "MIT",
-  "engine": {
+  "engines": {
     "node": "0.6.x"
   }
 }


### PR DESCRIPTION
Hi!

When I tried to deploy Uptime into a Heroku app their server complained about the "engine" attribute in the package.json. Heroku was searching for a "engines" attribute instead of "engine" so they refused the app.

I checked the npm documentation, it looks like the correct is "engines":

https://npmjs.org/doc/json.html#engines

So I changed the package.json and submitted you this pull-request :)

Thanks!
