### PR TITLE
Make app.js compatible with node.js 0.6.X

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,6 +93,7 @@ io.sockets.on('connection', function(socket) {
 });
 
 // load plugins
+fs.exists = fs.exists || require('path').exists;
 fs.exists('./plugins/index.js', function(exists) {
   if (exists) {
     require('./plugins').init(app, io, config, mongoose);


### PR DESCRIPTION
fs.exists did not exist yet in 0.6.X. It was path.exists.
This is a trick I found in an issue of another node.js project on github ...
