### PR TITLE
Added Prowl app support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,3 @@ plugins/index.js
 node_modules
 npm-debug.log
 *.swp
-
-#exclude osx and phpstorm files
-.DS_Store
-/.idea/*

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "semver":    "1.1.0",
     "moment":    "1.7.2",
     "nodemailer": "0.3.35",
-    "prowler": "*",
-    "boxcar": "*"
+    "prowler": "0.0.3"
   },
   "devDependencies": {
     "mocha": "1.7.x",


### PR DESCRIPTION
Added prowl app support. 
Prowl is a paid app available on the appstore. 
It seems to be one of the cheapest option to have push notifications on iOs.
