### PR TITLE
Fix for the Issue #79 - carriage return in plugin email "up" template

### DIFF
--- a/plugins/email/views/up.ejs
+++ b/plugins/email/views/up.ejs
@@ -1,19 +1,12 @@
-<%
-
-if (checkEvent.downtime) {
-
-%>[Up] Check "<%= check.name %>" went back up
+<% if (checkEvent.downtime) { -%>
+[Up] Check "<%= check.name %>" went back up
 On <%= moment(checkEvent.timestamp).format('LLLL') %>,
-and after <%= moment.duration(checkEvent.downtime).humanize() %> of downtime,<%
-
-} else {
-
-%>[Up] Check "<%= check.name %>" is now up
-On <%= moment(checkEvent.timestamp).format('LLLL') %>,<%
-
-}
-
-%>a test on URL "<%= check.url %>" responded correctly.
+and after <%= moment.duration(checkEvent.downtime).humanize() %> of downtime,
+<% } else { -%>
+[Up] Check "<%= check.name %>" is now up
+On <%= moment(checkEvent.timestamp).format('LLLL') %>,
+<% }%>
+a test on URL "<%= check.url %>" responded correctly.
 
 <% include details %>
-<% include footer %> 
+<% include footer %>


### PR DESCRIPTION
I have removed the carriage returns around the "if then else" condition, in the "up.js" template of the email plugin.
This was causing the email up notification subject to be empty
As it is a minor fix I have kept it in the "master" branch

Greg
