### PR TITLE
Fixing userAgent in the default.yaml

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -10,7 +10,7 @@ monitor:
   apiUrl:                 'http://localhost:8082/api' # must be accessible without a proxy
   pollingInterval:        10000      # ten seconds
   timeout:                5000       # five seconds
-  userAgent:              NodeUptime/2.0 (https://github.com/fzaninotto/uptime)
+  userAgent:              NodeUptime/3.0 (https://github.com/fzaninotto/uptime)
 
 analyzer:
   updateInterval:         60000      # one minute


### PR DESCRIPTION
As the current version is 3.0 I think it's more relevant to propose the same version in the default userAgent (in default.yaml)
