### PR TITLE
Sockets.io should follow the protocol used by the client hitting the dashboard

### DIFF
--- a/app/dashboard/views/layout.ejs
+++ b/app/dashboard/views/layout.ejs
@@ -13,7 +13,7 @@
     <script src="<%= route %>/javascripts/jquery.min.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script>
-    var socket = io.connect('http://' + location.hostname);
+    var socket = io.connect(location.protocol + '//' + location.hostname);
     </script>
     <script src="<%= route %>/javascripts/moment.min.js"></script>
     <!--[if lt IE 9]>


### PR DESCRIPTION
This small patch will create the socket.io connection on the client using the same protocol that the client used to connect to the website. So if they are using HTTPS, then the WebSocket (or fall backs) will use a secure link.
