### PR TITLE
Remove unnecessary toString call.

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -82,7 +82,7 @@ Monitor.prototype.findChecksNeedingPoll = function(callback) {
     }
     var body = '';
     res.on('data', function(chunk) {
-      body += chunk.toString();
+      body += chunk;
     });
     res.on('end', function() {
       callback(null, JSON.parse(body));


### PR DESCRIPTION
The chunk will be cast to string automatically since body is a string.
