### PR TITLE
Updating http and https pollers to allow '403 Forbidden' status codes

### DIFF
--- a/lib/pollers/http.js
+++ b/lib/pollers/http.js
@@ -109,6 +109,18 @@ HttpPoller.prototype.onResponseCallback = function(res) {
       poller.debug(poller.getTime() + "ms - Request Finished");
       poller.callback(undefined, poller.getTime(), body);
     });
+  } else if (statusCode == 403) {
+    var body = '';
+    this.debug(this.getTime() + "ms - Status code 403 Forbidden");
+    res.on('data', function(chunk) {
+      body += chunk.toString();
+      poller.debug(poller.getTime() + 'ms - BODY: ' + chunk.toString().substring(0, 100) + '...');
+    });
+    res.on('end', function() {
+      poller.timer.stop();
+      poller.debug(poller.getTime() + "ms - Request Finished");
+      poller.callback(undefined, poller.getTime(), body);
+    });
   } else {
     this.request.abort();
     this.onErrorCallback({ name: "NonOkStatusCode", message: "HTTP status " + statusCode});

--- a/lib/pollers/https.js
+++ b/lib/pollers/https.js
@@ -108,6 +108,18 @@ HttpsPoller.prototype.onResponseCallback = function(res) {
       poller.debug(poller.getTime() + "ms - Request Finished");
       poller.callback(undefined, poller.getTime(), body);
     });
+  } else if (statusCode == 403) {
+    var body = '';
+    this.debug(this.getTime() + "ms - Status code 403 Forbidden");
+    res.on('data', function(chunk) {
+      body += chunk.toString();
+      poller.debug(poller.getTime() + 'ms - BODY: ' + chunk.toString().substring(0, 100) + '...');
+    });
+    res.on('end', function() {
+      poller.timer.stop();
+      poller.debug(poller.getTime() + "ms - Request Finished");
+      poller.callback(undefined, poller.getTime(), body);
+    });
   } else {
     this.request.abort();
     this.onErrorCallback({ name: "NonOkStatusCode", message: "HTTP status " + statusCode});


### PR DESCRIPTION
Updating http and https pollers to allow '403 Forbidden' status codes
along with 200 as a valid response, which would help to support checking
if Selenium Grid Nodes are up and running
