### PR TITLE
Compatibility for node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "dependencies": {
     "mongoose":  "3.2.2",
     "mongoose-lifecycle": "1.0.0",
-    "express":   "3.0.0",
+    "express":   "3.1.0",
     "express-partials": "0.0.6",
     "connect-flash": "0.1.0",
     "ejs":       "0.8.0",
     "config":    "0.4.15",
     "async":     "0.1.22",
-    "socket.io": "0.9.10",
+    "socket.io": "0.9.13",
     "semver":    "1.1.0",
     "moment":    "1.7.2",
     "nodemailer": "0.3.35"


### PR DESCRIPTION
Updated express and socket.io

Solving the "Error: Can't set headers after they are sent." people using node 0.10 were seeing.
