### PR TITLE
Move the plugin installation logic to the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Uptime Changelog
 To be released
 --------------
 
+* Update the README about the plugin system
+* Update plugins system to make it easier to enable new plugins, just by adding a line in the configuration
 * Add pollerCollections to allow the addition of custom pollers
 * Update HTTP and HTTPS pollers (they now specialize a BaseHttpPoller, to reduce code duplication)
 * Fix monitor crash when poller is badly set
@@ -15,7 +17,6 @@ To be released
 * Add new events to Monitor and dashboard app
 * Add more plugins extension points: they can now add details to checks, abilities to pollers, and store additional details about pings
 * Move Pattern Matcher logic to a plugin
-* Update the README accordingly
 * Fix warnings in production by using cookie store for sessions
 * Add mention of external plugins in README
 * Add pattern detection in response body

--- a/app.js
+++ b/app.js
@@ -95,6 +95,20 @@ io.sockets.on('connection', function(socket) {
 });
 
 // load plugins
+config.plugins.forEach(function(pluginName) {
+  var plugin = require(pluginName);
+  if (typeof plugin.initWebApp !== 'function') return;
+  console.log('loading plugin %s on app', pluginName);
+  plugin.initWebApp({
+    app:       app,
+    api:       apiApp,       // mounted into app, but required for events
+    dashboard: dashboardApp, // mounted into app, but required for events
+    io:        io,
+    config:    config,
+    mongoose:  mongoose
+  });
+});
+// old way to load plugins, kept for BC
 fs.exists('./plugins/index.js', function(exists) {
   if (exists) {
     var pluginIndex = require('./plugins');

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,6 +22,11 @@ autoStartMonitor: true
 server:
   port:     8082
 
+plugins:
+  - ./plugins/console
+  - ./plugins/patternMatcher
+  # - ./plugins/email
+
 email:
   method:      SMTP  # possible methods are SMTP, SES, or Sendmail
   transport:         # see https://github.com/andris9/nodemailer for transport options

--- a/monitor.js
+++ b/monitor.js
@@ -6,16 +6,14 @@ var Monitor = require('./lib/monitor');
 monitor = Monitor.createMonitor(config.monitor);
 
 // load plugins
-fs.exists('./plugins/index.js', function(exists) {
-  if (exists) {
-    var pluginIndex = require('./plugins');
-    if (typeof pluginIndex.initMonitor === 'function') {
-      pluginIndex.initMonitor({
-        monitor: monitor,
-        config:  config
-      });
-    }
-  }
+config.plugins.forEach(function(pluginName) {
+  var plugin = require(pluginName);
+  if (typeof plugin.initMonitor !== 'function') return;
+  console.log('loading plugin %s on monitor', pluginName);
+  plugin.initMonitor({
+    monitor: monitor,
+    config:  config
+  });
 });
 
 monitor.start();

--- a/plugins/console/index.js
+++ b/plugins/console/index.js
@@ -3,16 +3,19 @@
  *
  * Logs all pings and events (up, down, paused, restarted) on the console
  *
- * To enable the plugin, call init() in the webapp hook in plugins/index.js
- *   exports.initWebApp = function() {
- *     require('./console').init();
- *   }
- * 
+ * Installation
+ * ------------
+ * This plugin is enabled by default. To disable it, remove its entry 
+ * from the `plugins` key of the configuration:
+ *
+ *   // in config/production.yaml
+ *   plugins:
+ *     # - ./plugins/console
  */
 var Ping = require('../../models/ping');
 var CheckEvent = require('../../models/checkEvent');
 
-exports.init = function(enableNewEvents, enableNewPings) {
+exports.initWebApp = function(enableNewEvents, enableNewPings) {
   if (typeof enableNewEvents == 'undefined') enableNewEvents = true;
   if (typeof enableNewPings == 'undefined') enableNewPings = true;
   if (enableNewEvents) registerNewEventsLogger();

--- a/plugins/patternMatcher/index.js
+++ b/plugins/patternMatcher/index.js
@@ -3,22 +3,18 @@
  *
  * Adds the ability to HTTP & HTTPS pollers to test the response body against a pattern
  *
- * The plugin must be enabled both in the monitor and in the webapp:
+ * Installation
+ * ------------
+ * This plugin is enabled by default. To disable it, remove its entry 
+ * from the `plugins` key of the configuration:
  *
- *   // in plugins/index.js
- *   var patternMatcherPlugin = require('./patternMatcher');
+ *   // in config/production.yaml
+ *   plugins:
+ *     # - ./plugins/patternMatcher
  *
- *   exports.initWebApp = function(options) {
- *     // enable patternMatcher for the webapp
- *     patternMatcherPlugin.initWebApp(options);
- *   };
- *
- *   exports.initMonitor = function(options) {
- *     // enable patternMatcher for the monitor
- *     patternMatcherPlugin.initMonitor(options);
- *   };
- *
- * Then, restart Uptime, and add a pattern to http checks in the dashboard UI.
+ * Usage
+ * -----
+ * Add a pattern to http checks in the dashboard UI.
  * Patterns are regexp, for instance '/hello/i'.
  *
  * When Uptime polls a check with a pattern, it tests the pattern against the 


### PR DESCRIPTION
- Enable console and patternMatcher plugins by default
- Keep old way to extend the frontend (via plugins/index.js) for BC
- Rewrite the plugin documentation
