### PR TITLE
Specified options argument for email plugin

### DIFF
--- a/plugins/email/index.js
+++ b/plugins/email/index.js
@@ -55,7 +55,7 @@ var moment     = require('moment');
 var CheckEvent = require('../../models/checkEvent');
 var ejs        = require('ejs');
 
-exports.initWebApp = function() {
+exports.initWebApp = function(options) {
   var config = options.config.email;
   var mailer = nodemailer.createTransport(config.method, config.transport);
   var templateDir = __dirname + '/views/';


### PR DESCRIPTION
fix for the email plugin throwing a ReferenceError for `options` not being defined
