### PR TITLE
Use Buffer.byteLength instead of string length for Content-Length header

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -182,7 +182,7 @@ Monitor.prototype.createPing = function(error, check, timestamp, time, details, 
   options.method = 'POST';
   options.headers = {
     'Content-Type': 'application/x-www-form-urlencoded',
-    'Content-Length': postData.length
+    'Content-Length': Buffer.byteLength(postData)
   };
   this.applyApiHttpOptions(options);
   var self = this;


### PR DESCRIPTION
This prevents Content-Length mismatches when sending multi-byte characters and potential socket hang ups.

See https://groups.google.com/forum/?fromgroups=#!topic/nodejs/LAxACfj5_KI.

http://stackoverflow.com/questions/18692580/node-js-post-causes-error-socket-hang-up-code-econnreset
