### PR TITLE
Add host as part of the server configuration options

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,7 +138,8 @@ fs.exists('./plugins/index.js', function(exists) {
 module.exports = app;
 if (!module.parent) {
   var port = process.env.PORT || config.server.port;
-  server.listen(port, function(){
+  var host = process.env.HOST || config.server.host;
+  server.listen(port, host, function(){
     console.log("Express server listening on port %d in %s mode", port, app.settings.env);
   });
 }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,6 +20,7 @@ analyzer:
 autoStartMonitor: true
 
 server:
+  host:     0.0.0.0
   port:     8082
 
 plugins:


### PR DESCRIPTION
Hi,

Here's a quick PR to add the host as part of the server.listen() call. This makes it possible to listen only on a specific IP (in my case 127.0.0.1) since I did not want to expose uptime on all of my interfaces.

By default it will keep the old behavior, that is listen on all interfaces.
