### PR TITLE
Accept all 2xx and 3xx HTTP status codes as successful

### DIFF
--- a/lib/pollers/http/baseHttpPoller.js
+++ b/lib/pollers/http/baseHttpPoller.js
@@ -56,7 +56,7 @@ BaseHttpPoller.prototype.onResponseCallback = function(res) {
   if (statusCode.match(/3\d{2}/)) {
     return this.handleRedirectResponse(res); // abstract, see implementations in http and https
   }
-  if (statusCode.match(/2\d{2}/) == null) {
+  if (statusCode.match(/2\d{2}/) === null) {
     return this.handleErrorResponse(res);
   }
   this.handleOkResponse(res);


### PR DESCRIPTION
Currently the only 2xx status code that handles as an OK response is "200" but some services I am monitoring return status codes of 201, 202, and 206. I used a match as a catch all for the 2xx and 3xx status code ranges.
