### PR TITLE
Add ability to define host in a single config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Configuring
 Uptime uses [node-config](https://github.com/lorenwest/node-config) to allow YAML configuration and environment support. Here is the default configuration, taken from `config/default.yaml`:
 
 ```yaml
+url:        'http://localhost:8082'
+
 mongodb:
   server:   localhost
   database: uptime
@@ -92,9 +94,6 @@ analyzer:
 
 autoStartMonitor: true
 
-server:
-  port:     8082
-
 plugins:
   - ./plugins/console
   - ./plugins/patternMatcher
@@ -105,8 +104,7 @@ plugins:
 To modify this configuration, create a `development.yaml` or a `production.yaml` file in the same directory, and override just the settings you need. For instance, to run Uptime on port 80 in production, create a `production.yaml` file as follows:
 
 ```yaml
-server:
-  port:     80
+url: 'http://myDomain.com'
 ```
 
 Node that Uptime works great behind a proxy - it uses the `http_proxy` environment variable transparently.

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
  */
 
 var http       = require('http');
+var url        = require('url');
 var express    = require('express');
 var config     = require('config');
 var socketIo   = require('socket.io');
@@ -136,14 +137,35 @@ fs.exists('./plugins/index.js', function(exists) {
 });
 
 module.exports = app;
+
+var monitorInstance;
+
 if (!module.parent) {
-  var port = process.env.PORT || config.server.port;
+  var serverUrl = url.parse(config.url);
+  var port;
+  if (config.server && config.server.port) {
+    console.error('Warning: The server port setting is deprecated, please use the url setting instead');
+    port = config.server.port;
+  } else {
+    port = serverUrl.port;
+    if (port === null) {
+      port = 80;
+    }
+  }
+  var port = process.env.PORT || port;
+  var host = process.env.HOST || serverUrl.hostname;
   server.listen(port, function(){
-    console.log("Express server listening on port %d in %s mode", port, app.settings.env);
+    console.log("Express server listening on host %s, port %d in %s mode", host, port, app.settings.env);
+  });
+  server.on('error', function(e) {
+    if (monitorInstance) {
+      monitorInstance.stop();
+      process.exit(1);
+    }
   });
 }
 
 // monitor
 if (config.autoStartMonitor) {
-  require('./monitor');
+  monitorInstance = require('./monitor');
 }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,3 +1,5 @@
+url: 'http://localhost:8082'
+
 mongodb:
   server:   localhost
   database: uptime
@@ -18,9 +20,6 @@ analyzer:
   pingHistory:            8035200000 # three months
 
 autoStartMonitor: true
-
-server:
-  port:     8082
 
 plugins:
   - ./plugins/console
@@ -44,7 +43,7 @@ email:
   message:           
     from:            # The message sender, e.g. 'Fred Foo <foo@blurdybloop.com>'
     to:              # The message recipient, e.g. 'bar@blurdybloop.com, baz@blurdybloop.com'
-  dashboardUrl: 'http://localhost:8082'
+  # The email plugin also uses the main `url` param for hyperlinks in the sent emails
 
 basicAuth:
   username:    admin

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -56,6 +56,7 @@ Monitor.prototype.start = function() {
  */
 Monitor.prototype.stop = function() {
   clearInterval(this.intervalForPoll);
+  console.log('Monitor ' + this.config.name + ' stopped');
 };
 
 /**

--- a/plugins/email/index.js
+++ b/plugins/email/index.js
@@ -47,7 +47,7 @@
  *     message:           
  *       from:     'Fred Foo <foo@blurdybloop.com>'
  *       to:       'bar@blurdybloop.com, baz@blurdybloop.com'
- *     dashboardUrl: 'http://localhost:8082'
+ *     # The email plugin also uses the main `url` param for hyperlinks in the sent emails
  */
 var fs         = require('fs');
 var nodemailer = require('nodemailer');
@@ -67,7 +67,7 @@ exports.initWebApp = function(options) {
       var renderOptions = {
         check: check,
         checkEvent: checkEvent,
-        url: config.dashboardUrl,
+        url: options.config.url,
         moment: moment,
         filename: filename
       };


### PR DESCRIPTION
Now, host and port are defined in a single config setting: `url`.

``` yaml
url: 'http://myDomain.com:8082'

# Now deprecated, will raise a warning
# server:
#  port: 8082
```

Supersedes #94, #227
