### PR TITLE
Use current version (0.6.5) of nodemailer

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "socket.io": "0.9.14",
     "semver":    "1.1.0",
     "moment":    "2.1.0",
-    "nodemailer": "0.3.35",
+    "nodemailer": "~0.6.5",
     "net-ping":  "1.1.7",
     "js-yaml": "2.1.0"
   },


### PR DESCRIPTION
I was getting a crash when using version 0.3.35 of nodemailer. Updating to the latest version caught the error and sent it to me via the callback. Is there a specific reason we are using this version of nodemailer?
