### PR TITLE
Fix IntervalBuilder crash during a check deletion

### DIFF
--- a/lib/intervalBuilder.js
+++ b/lib/intervalBuilder.js
@@ -45,12 +45,12 @@ IntervalBuilder.prototype.build = function(begin, end, callback) {
         self.getCurrentCheck(next)
     }],
     duration: ['initialState', 'interval', 'check', function (next, results) {
-        if (typeof check !== 'undefined' && check != null) {
+        if (typeof results.check !== 'undefined' && results.check != null) {
           self.calculateDuration(results.check, begin, end, next);
         }
     }],
     downtime: ['initialState', 'interval', 'check', 'duration', function (next, results) {
-        if (typeof check !== 'undefined' && check != null) {
+        if (typeof results.check !== 'undefined' && results.check != null) {
           self.calculateDowntime(results.check, begin, end, next);
         };
     }]

--- a/lib/intervalBuilder.js
+++ b/lib/intervalBuilder.js
@@ -45,12 +45,12 @@ IntervalBuilder.prototype.build = function(begin, end, callback) {
         self.getCurrentCheck(next)
     }],
     duration: ['initialState', 'interval', 'check', function (next, results) {
-        if (check != null) {
+        if (typeof check !== 'undefined' && check != null) {
           self.calculateDuration(results.check, begin, end, next);
         }
     }],
     downtime: ['initialState', 'interval', 'check', 'duration', function (next, results) {
-        if (check != null) {
+        if (typeof check !== 'undefined' && check != null) {
           self.calculateDowntime(results.check, begin, end, next);
         };
     }]

--- a/lib/intervalBuilder.js
+++ b/lib/intervalBuilder.js
@@ -45,10 +45,14 @@ IntervalBuilder.prototype.build = function(begin, end, callback) {
         self.getCurrentCheck(next)
     }],
     duration: ['initialState', 'interval', 'check', function (next, results) {
-        self.calculateDuration(results.check, begin, end, next);
+        if (check != null) {
+          self.calculateDuration(results.check, begin, end, next);
+        }
     }],
     downtime: ['initialState', 'interval', 'check', 'duration', function (next, results) {
-        self.calculateDowntime(results.check, begin, end, next);
+        if (check != null) {
+          self.calculateDowntime(results.check, begin, end, next);
+        };
     }]
     }, function(err, results) {
       if (err) {

--- a/lib/intervalBuilder.js
+++ b/lib/intervalBuilder.js
@@ -45,12 +45,12 @@ IntervalBuilder.prototype.build = function(begin, end, callback) {
         self.getCurrentCheck(next)
     }],
     duration: ['initialState', 'interval', 'check', function (next, results) {
-        if (typeof results.check !== 'undefined' && results.check != null) {
+        if (typeof results.check !== 'undefined' && results.check !== null) {
           self.calculateDuration(results.check, begin, end, next);
         }
     }],
     downtime: ['initialState', 'interval', 'check', 'duration', function (next, results) {
-        if (typeof results.check !== 'undefined' && results.check != null) {
+        if (typeof results.check !== 'undefined' && results.check !== null) {
           self.calculateDowntime(results.check, begin, end, next);
         };
     }]


### PR DESCRIPTION
As I said in #243, if we delete a check with a huge pings history, it's very long (Because of I/O mass operations, #245) and finally crash certainly because the `IntervalBuilder` try to calculate duration and/or downtime of a check that doesn't exist anymore.

I managed to find a workaround by invoking the calculation function only if check exists.

I don't know if is the best way but now, the very long delete processing works after all and the all of the uptime system seems to work properly.
