### PR TITLE
Add possibility of remove pings/events cascade deleting on check remove

### DIFF
--- a/app/dashboard/views/_events.ejs
+++ b/app/dashboard/views/_events.ejs
@@ -55,7 +55,7 @@ $(document).ready(function() {
       $.each(events, function(key, eventGroup) {
         lines.push('<ul><li class="day"><h3>' + moment(key).format('dddd, MMMM Do') + '</h3><ul>');
         $.each(eventGroup, function(key, event) {
-          if (!event.message) return;
+          if (!event.message || !event.check) return;
           lines.push(ejs.render(event_template, { event: event, date: moment(event.timestamp), highlightFrom: highlightFrom, route: '<%= route %>' }));
           nbEvents++;
         });

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,6 +21,9 @@ analyzer:
 
 autoStartMonitor: true
 
+pingCascadeDelete: true
+eventCascadeDelete: true
+
 plugins:
   - ./plugins/console
   - ./plugins/patternMatcher

--- a/models/check.js
+++ b/models/check.js
@@ -36,12 +36,12 @@ var Check = new Schema({
 Check.plugin(require('mongoose-lifecycle'));
 
 Check.pre('remove', function(next) {
-  var methods = [this.removeStats.bind(this)]
+  var methods = [this.removeStats.bind(this)];
 
   if (config.pingCascadeDelete === true)
-    methods.push(this.removePings.bind(this))
+    methods.push(this.removePings.bind(this));
   if (config.eventCascadeDelete === true)
-    methods.push(this.removeEvents.bind(this))
+    methods.push(this.removeEvents.bind(this));
 
   async.parallel(methods, function() {
     next();

--- a/models/check.js
+++ b/models/check.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 var Schema   = mongoose.Schema;
 var moment   = require('moment');
 var async    = require('async');
+var config   = require('config');
 
 // models dependencies
 var Ping             = require('../models/ping');
@@ -35,7 +36,14 @@ var Check = new Schema({
 Check.plugin(require('mongoose-lifecycle'));
 
 Check.pre('remove', function(next) {
-  async.parallel([this.removePings.bind(this), this.removeEvents.bind(this), this.removeStats.bind(this)], function() {
+  var methods = [this.removeStats.bind(this)]
+
+  if (config.pingCascadeDelete === true)
+    methods.push(this.removePings.bind(this))
+  if (config.eventCascadeDelete === true)
+    methods.push(this.removeEvents.bind(this))
+
+  async.parallel(methods, function() {
     next();
   });
 });


### PR DESCRIPTION
If we have checks with huge pings/events history, the cascade delete is very long and painful. :snail:

I added here the possibility of desactivate the cascade deletion in config file.
If you desactivate it pings or/and events won't be removed on check delete. In any case, it will be remove because of `pingHistory` configuration for analyzer.

The two parameters are set to `true` by default in order to avoid BC break.

You **MUST** merge PR #246 before this! If not, the app will crash like described in #243 or #218.

I'm not an expert of NodeJS, so don't hesitate to give me some reviews! ;)
