### PR TITLE
Add possibility of delete a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,14 @@ Parameter :
 
 Ex: `http://localhost:8082/tags/good`
 
+#### `DELETE /tags/:name`
+
+Return a tag
+
+Parameter :
+
+* `name` : (required) name of the tag
+
 #### `PUT /checks`
 
 Create a new check and return it

--- a/app/api/routes/tag.js
+++ b/app/api/routes/tag.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 
+var Check         = require('../../../models/check');
 var Tag           = require('../../../models/tag');
 var TagHourlyStat = require('../../../models/tagHourlyStat');
 var CheckEvent    = require('../../../models/checkEvent');
@@ -76,6 +77,18 @@ module.exports = function(app) {
         res.json(aggregatedEvents);
       });
     });
+  });
+
+  app.delete('/tags/:name', loadTag, function(req, res, next) {
+    // Delete tag relation first in order to avoid magic respawn
+    Check.collection.update({ tags: req.tag.name }, { $pull: { tags: req.tag.name } }, { multi: true }, function(err) {
+      if (err) return next(err);
+      // Then, remove the tag
+      req.tag.remove(function(err2) {
+        if (err2) return next(err2);
+        res.end();
+      });
+    })
   });
 
 };

--- a/app/dashboard/views/tag.ejs
+++ b/app/dashboard/views/tag.ejs
@@ -11,6 +11,12 @@ ejs.open = '{{';
 ejs.close = '}}';
 var page = {};
 </script>
+<div style="float: right;">
+  <form id="tag_delete_form" method="post" action="<%= route %>/tags/<%= tag.name %>">
+    <input type="hidden" name="_method" value="delete" />
+    <button type="submit" class="btn btn-danger pull-right" name="delete">Delete</button>
+  </form>
+</div>
 <h1>
   Tag "<%= tag.name %>"
 </h1>
@@ -75,6 +81,11 @@ var dateInterval = new DateInterval(
   'day'
 );
 jQuery(document).ready(function($) {
+  // Tag delete confirmation
+  $('#tag_delete_form button[name="delete"]').click(function() {
+    return confirm("This will delete the tag \"<%= tag.name %>\" and his checks relations.\nAre you sure?");
+  });
+
   // highlight current section in main nav
   $('.navbar-inner li').eq(2).addClass('active');
 

--- a/app/dashboard/views/tags.ejs
+++ b/app/dashboard/views/tags.ejs
@@ -1,4 +1,7 @@
 <h1>Tags <small class="pull-right">last 24 hours</small></h1>
+<% if (info.length) { %>
+<div class="alert alert-success"><%= info %></div>
+<% } %>
 <table class="table chart" id="tags">
   <thead>
     <tr>


### PR DESCRIPTION
As request on issue #121, here is a PR to add the possibility of delete a tag.

In a nutshell:
- Tag deletion will remove Check / Tags relation first, in order to avoid magic tag re-spawn
- Tag deletion action is available in the tag show page, red button in the top-right corner
- Tag deletion is also available on API, please see the Readme.

Thanks for taking a look!
