### PR TITLE
Add email alert attribute to checks closes #269

### DIFF
--- a/plugins/email/views/_detailsEdit.ejs
+++ b/plugins/email/views/_detailsEdit.ejs
@@ -1,0 +1,8 @@
+<fieldset>
+  <div class="control-group">
+    <label class="control-label">Alert Email</label>
+    <div class="controls">
+      <input type="text" name="check[alert_email]" value="<%= check.getPollerParam('alert_email') || '' %>" class="span8" placeholder="Email address to send alerts for this check. Leave blank to use default."/>
+    </div>
+  </div>
+</fieldset>


### PR DESCRIPTION
Following issue #269 - i've added an "Alert Email" field to the check edit screen - allows you to set a different email to receive the alert for this check.  I've added to the 'afterInsert' event this logic: check if the Check has an alert_email defined, if so, mail to there instead of what's defined in the config yaml file.
