### PR TITLE
added: HTTPS capability, yargs CLI option parser

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,7 +3,7 @@ url: 'http://localhost:8082'
 mongodb:
   server:   localhost
   database: uptime
-  user:     root 
+  user:     root
   password:
   connectionString:       # alternative to setting server, database, user and password separately
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "nodemailer": "0.3.35",
     "net-ping":  "1.1.7",
     "js-yaml": "2.1.0",
-    "webpagetest": "0.2.0"
+    "webpagetest": "0.2.0",
+    "yargs": "1.3.3"
   },
   "devDependencies": {
     "mocha": "1.7.x",


### PR DESCRIPTION
Aloha again. This is just a tiny little addition to enable HTTPS connections to the web UI. HTTPS is turned on in the Uptime UI server if the command-line options for "certificate" and "key" are specified, otherwise it defaults back to regular HTTP. CLI option parsing is done using [yargs](https://www.npmjs.com/package/yargs). Thanks for looking! :)