### PR TITLE
Optimize Regex.match() to indexOf()

### DIFF
--- a/lib/pollers/http/baseHttpPoller.js
+++ b/lib/pollers/http/baseHttpPoller.js
@@ -53,10 +53,10 @@ BaseHttpPoller.prototype.setUserAgent = function(userAgent) {
  */
 BaseHttpPoller.prototype.onResponseCallback = function(res) {
   var statusCode = res.statusCode.toString();
-  if (statusCode.match(/3\d{2}/)) {
+  if (statusCode.indexOf('3') === 0) {
     return this.handleRedirectResponse(res); // abstract, see implementations in http and https
   }
-  if (statusCode.match(/2\d{2}/) === null) {
+  if (statusCode.indexOf('2') !== 0) {
     return this.handleErrorResponse(res);
   }
   this.handleOkResponse(res);


### PR DESCRIPTION
Simple change to optimize returned status code handler. With huge number of hosts, regex creates bottleneck. Changing Regex.match() to indexOf() reduces load.