### PR TITLE
fixed http_proxy env var reading

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -24,7 +24,7 @@ if (process.env.http_proxy) {
     newOptions.path     = "http://" + options.hostname + ":" + (options.port || 80) + options.path;
     newOptions.hostname = httpProxy.hostname;
     newOptions.port     = httpProxy.port;
-    newOptions.protocol = httpsProxy.protocol;
+    newOptions.protocol = httpProxy.protocol;
     if (httpProxy.protocol === 'https:') {
       return httpsRequest(newOptions, callback);
     } else {


### PR DESCRIPTION
In the current version if you set the environment variable `http_proxy` but doesn't set `https_proxy` the application crashes.

It's just a typo in the code.
