### PR TITLE
Disable the invalid external link when create a new check

### DIFF
--- a/app/dashboard/views/_checkDetails.ejs
+++ b/app/dashboard/views/_checkDetails.ejs
@@ -11,7 +11,7 @@
             <label class="control-label">Url</label>
             <div class="controls controls-row">
               <input type="text" required name="check[url]" value="<%= check.url || '' %>" class="span5"  placeholder="http://www.example.com"/>
-              <span class="help-inline" style="position:absolute"><a href="<%= check.url %>" target="_blank"><img src="<%= route %>/images/external-link-ltr-icon.png"></a></span>
+              <span class="help-inline" style="position:absolute"><a href="<%= check.url || 'javascript:void 0;' %>" target="_blank"><img src="<%= route %>/images/external-link-ltr-icon.png"></a></span>
             </div>
           </div>
         </fieldset>


### PR DESCRIPTION
When create a new check, the external link for check url is `localhost:8082/dashboard/checks/undefinde`. 

It will cause a `500 CastError: Cast to ObjectId failed for value "undefinded" at path "_id"`.

Need disable the external link in that page.