### PR TITLE
Improve notification when pause and restart a checker

### DIFF
--- a/app/api/app.js
+++ b/app/api/app.js
@@ -51,6 +51,7 @@ var refreshUpCount = function(callback) {
 
 Check.on('afterInsert', function() { upCount = undefined; });
 Check.on('afterRemove', function() { upCount = undefined; });
+Check.on('afterUpdate', function() { upCount = undefined; });
 CheckEvent.on('afterInsert', function() { upCount = undefined; });
 
 app.get('/checks/count', function(req, res, next) {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,9 +3,9 @@ url: 'http://localhost:8082'
 mongodb:
   server:   localhost
   database: uptime
-  user:     root 
-  password:
-  connectionString:       # alternative to setting server, database, user and password separately
+  user:     uptime 
+  password: robot
+  connectionString: mongodb://localhost/uptime # alternative to setting server, database, user and password separately
 
 monitor:
   name:                   origin
@@ -13,6 +13,7 @@ monitor:
   pollingInterval:        10000      # ten seconds
   timeout:                5000       # five seconds
   userAgent:              NodeUptime/3.0 (https://github.com/fzaninotto/uptime)
+  debug:                  true       # monitor log debug mode
 
 analyzer:
   updateInterval:         60000      # one minute
@@ -48,6 +49,7 @@ email:
 basicAuth:
   username:    admin
   password:    password
+
 verbose: true # only used in dev
 
 webPageTest:

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -142,7 +142,11 @@ Monitor.prototype.pollCheck = function(check, callback) {
   } catch (incorrectPollerUrl) {
     return self.createPing(incorrectPollerUrl, check, now, 0, details, callback);
   }
-  //p.setDebug(true);
+  
+  if(this.config.debug){
+    p.setDebug(true);  
+  }
+
   p.poll();
 };
 

--- a/models/check.js
+++ b/models/check.js
@@ -153,6 +153,10 @@ Check.methods.mustNotifyEvent = function(status) {
     // check goes up after reaching the down alert treshold before
     return true;
   }
+
+  // reset count because status is already up 
+  this.errorCount = 0;  
+
   // check either goes up after less than alertTreshold down pings, or is already up for long
   return false;
 };

--- a/models/check.js
+++ b/models/check.js
@@ -17,10 +17,11 @@ var Check = new Schema({
   name        : String,
   type        : String,
   url         : String,
-  interval    : { type: Number, default: 60000 }, // interval between two pings
-  maxTime     : { type: Number, default: 1500 },  // time under which a ping is considered responsive
-  alertTreshold : { type: Number, default: 1 },   // nb of errors from which to trigger a new CheckEvent
-  errorCount  : { type: Number, default: 0 },     // count number of errors
+  interval    : { type: Number, default: 60000 },  // interval between two pings
+  maxTime     : { type: Number, default: 1500 },   // time under which a ping is considered responsive
+  alertTreshold : { type: Number, default: 1 },    // nb of errors from which to trigger a new CheckEvent
+  errorCount  : { type: Number, default: 0 },      // count number of errors
+  alertState  : { type: Boolean, default: false }, // state is true when errorCount greater than alertTreshold and already triggered notification
   tags        : [String],
   lastChanged : Date,
   firstTested : Date,
@@ -115,7 +116,7 @@ Check.methods.setLastTest = function(status, time, error) {
       event.downtime = now.getTime() - this.lastChanged.getTime();
     }
     event.save();
-    this.markEventNotified();
+    this.changeAlertState(status);
   }
   var durationSinceLastChange = now.getTime() - this.lastChanged.getTime();
   if (status) {
@@ -135,35 +136,40 @@ Check.methods.mustNotifyEvent = function(status) {
     if (this.isUp != status) {
       // check goes down for the first time
       this.errorCount = 1;
-    }
-    if (this.errorCount < this.alertTreshold) {
-      // repeated down pings - increase error count until reaching the down alert treshold
+    }else{
       this.errorCount++;
-      return false;
     }
-    if (this.errorCount === this.alertTreshold) {
-      // enough down pings to trigger notification
+    
+    if (this.errorCount >= this.alertTreshold && this.alertState == false) {
+      // turn "red light" on, trigger notification
       return true;
     }
-    // error count higher than treshold, that means the alert was already sent
+
+    // nothing to do, error count less than treshold
     return false;
   }
+  
   // check is up
-  if (this.isUp != status && this.errorCount > this.alertTreshold) {
-    // check goes up after reaching the down alert treshold before
+  if (this.isUp != status && this.alertState) {
+    // reset errorCount because status is already up 
+    this.errorCount = 0;
+
+    // thurn "red light" off, trigger notificaiton
     return true;
   }
 
-  // reset count because status is already up 
-  this.errorCount = 0;  
-
-  // check either goes up after less than alertTreshold down pings, or is already up for long
+  // nothing to do, example when pause and restart a checker with last state is up don't need trigger "up" notification
   return false;
 };
 
-Check.methods.markEventNotified = function() {
-  // increase error count to disable notification if the next ping has the same status
-  this.errorCount = this.alertTreshold + 1;
+Check.methods.changeAlertState = function(status) {
+  if(status){
+    // status up make "red light" off, no more alert state
+    this.alertState = false;
+  }else{
+    // status down make "red light" on
+    this.alertState = true;
+  }
 };
 
 Check.methods.getQosPercentage = function() {

--- a/plugins/patternMatcher/index.js
+++ b/plugins/patternMatcher/index.js
@@ -23,7 +23,7 @@
 var fs   = require('fs');
 var ejs  = require('ejs');
 
-var matchPattern = '^/(.*?)/(g?i?m?y?)$';
+var matchPattern = '^/(.*?)/([gimy]*)$';
 var template = fs.readFileSync(__dirname + '/views/_detailsEdit.ejs', 'utf8');
 
 exports.initWebApp = function(options) {


### PR DESCRIPTION
When you pause and restart a checker, 3 notification are trigger. One event is "paused", another "restarted" and last "up". 

However, if the last status of checker was "up", before pause and restart, isn't necessary trigger "up" event. 

We know is possible after restart one checker may craft. In this case, one "down" event will trigger normally.