### PR TITLE
remove `id` from the error message

### DIFF
--- a/app/api/routes/ping.js
+++ b/app/api/routes/ping.js
@@ -48,7 +48,7 @@ module.exports = function(app) {
         return res.send(err1.message, 500);
       }
       if (!check) {
-        return res.send('Error: No existing check with id ' + req.body.checkId, 403);
+        return res.send('Error: No existing check with provided id', 403);
       }
       if (!check.needsPoll) {
         return res.send('Error: This check was already polled. No ping was created', 403);


### PR DESCRIPTION
`res.send()` is sending a string value as an HTML content by default, that is why reflecting the user provided `id` without any sanitization can be vulnerable to XSS.